### PR TITLE
fix: accidentally adding revision record when changing the `No of pages`

### DIFF
--- a/main.py
+++ b/main.py
@@ -2401,6 +2401,7 @@ def get(
             action_buttons,
             action="/revision/bulk_add",
             method="POST",
+            onkeydown="if(event.key === 'Enter') event.preventDefault();"
         ),
         Script(src="/public/script.js"),
         active="Home",


### PR DESCRIPTION
This bug might happen when the user clicks the "Enter" button on the keyboard instinctively.